### PR TITLE
fix: remove filtering & sorting on unused cols in storage

### DIFF
--- a/src/component/customTable/CustomTh.tsx
+++ b/src/component/customTable/CustomTh.tsx
@@ -110,6 +110,7 @@ export const CustomTh: FC<CustomThProps> = (props) => {
                 <IconButton
                   aria-label="search-column-btn"
                   size="sm"
+                  fontSize={16}
                   variant="ghost"
                   icon={<FiSearch />}
                   onClick={handleSearchBtnClick}
@@ -130,6 +131,7 @@ export const CustomTh: FC<CustomThProps> = (props) => {
           <IconButton
             aria-label="sort-column-btn"
             size="sm"
+            fontSize={16}
             variant="ghost"
             icon={getSortBtnIcon()}
             onClick={handleSortDirectionChange}

--- a/src/constant/tables.ts
+++ b/src/constant/tables.ts
@@ -12,22 +12,22 @@ export const STORAGE_GOODS_TABLE_COLUMNS: (TableColumn | null)[] = [
     name: "SKU segment",
     param: "uniquename",
     isSearchable: true,
-    isSortable: true,
+    isSortable: false,
   },
-  { name: "Name", param: "name", isSearchable: true, isSortable: true },
+  { name: "Name", param: "name", isSearchable: true, isSortable: false },
   {
     name: "Total quantity",
     param: "quantity",
-    isSearchable: true,
+    isSearchable: false,
     isSortable: true,
   },
   {
     name: "Boxes quantity",
     param: "box_quantity",
-    isSearchable: true,
-    isSortable: true,
+    isSearchable: false,
+    isSortable: false,
   },
-  { name: "Shelf", param: "shelf", isSearchable: true, isSortable: true },
+  { name: "Shelf", param: "shelf", isSearchable: false, isSortable: false },
   null,
 ]
 


### PR DESCRIPTION
- Поправил сортировку и фильтрацию по колонках в **Storage**
- Оставил сортировку только на колонках `ID`, `TOTAL QUANTITY`
- Оставил фильтрацию только на колонках `ID`, `SKU SEGMENT`, `NAME`
